### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ This step can be parallelized depending on your computing system. For example, t
 
 ```
 # an example for generating sample.vcf from sample.bam mapped to hg19
-samtools mpileup -I -uf hg19.fasta -l SNP_GRCh37_hg19_woChr.bed sample.bam | bcftools view -cg - > ./sample.vcf
+samtools mpileup -I -uf hg19.fasta -l SNP_GRCh37_hg19_woChr.bed sample.bam | \
+  bcftools call -c - > ./sample.vcf
 ```
    
 * STEP2: Run NGSCheckMate on the set of VCF files as input.


### PR DESCRIPTION
This PR updates the suggested samtools/bcftools command for generating VCF files to be used in NGSCheckMate. Specifically, it changes `bcftools view` to `bcftools call` which is what NGSCheckMate uses when run in BAM mode. This hopefully helps with consistency.